### PR TITLE
Fast redirect

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@itznotabug/routex",
-    "version": "0.0.1",
+    "version": "0.0.2",
     "type": "module",
     "description": "A client side redirection plugin for Vitepress.",
     "author": "@itznotabug",

--- a/src/engine/generator.ts
+++ b/src/engine/generator.ts
@@ -49,13 +49,20 @@ export class RedirectGenerator {
         const template = await templateManager.resolveTemplate();
         const metaTags = this.createMetaTags(destination, delay);
 
-        return templateManager.processTemplate(
+        const processedTemplate = templateManager.processTemplate(
             template,
             source,
             destination,
             metaTags,
             delay,
         );
+
+        if (delay === 0) {
+            // faster redirect if delay is 0.
+            return this.injectClientScript(processedTemplate);
+        }
+
+        return processedTemplate;
     }
 
     async generateAllRedirectFiles(outDir: string): Promise<void> {

--- a/src/engine/generator.ts
+++ b/src/engine/generator.ts
@@ -43,7 +43,7 @@ export class RedirectGenerator {
     injectProductionClientScript(html: string, destination: string) {
         // quick, small and efficient
         const scriptContent = `var d=${JSON.stringify(destination)};try{location.replace(d)}catch(e){location.href=d}`;
-        const script = `<script>\n        ${scriptContent.split('\n').join('\n        ')}\n    </script>`;
+        const script = `<script>${scriptContent}</script>`;
         return html.replace('<head>', `<head>\n    ${script}`);
     }
 

--- a/src/engine/generator.ts
+++ b/src/engine/generator.ts
@@ -15,7 +15,7 @@ export class RedirectGenerator {
         private vitepressConfig?: VitePressConfig,
     ) {}
 
-    injectClientScript(html: string): string {
+    injectDevelopmentClientScript(html: string): string {
         const redirectsJson = JSON.stringify(this.rules, null, 2);
 
         const scriptContent = `
@@ -40,6 +40,13 @@ export class RedirectGenerator {
         return html.replace('<head>', `<head>\n    ${script}`);
     }
 
+    injectProductionClientScript(html: string, destination: string) {
+        // quick, small and efficient
+        const scriptContent = `var d=${JSON.stringify(destination)};try{location.replace(d)}catch(e){location.href=d}`;
+        const script = `<script>\n        ${scriptContent.split('\n').join('\n        ')}\n    </script>`;
+        return html.replace('<head>', `<head>\n    ${script}`);
+    }
+
     async generateRedirectPage(
         source: string,
         destination: string,
@@ -59,7 +66,10 @@ export class RedirectGenerator {
 
         if (delay === 0) {
             // faster redirect if delay is 0.
-            return this.injectClientScript(processedTemplate);
+            return this.injectProductionClientScript(
+                processedTemplate,
+                destination,
+            );
         }
 
         return processedTemplate;

--- a/src/routex.ts
+++ b/src/routex.ts
@@ -56,7 +56,7 @@ export function routex(config: RedirectConfig): Plugin {
                 options,
                 vitePressConfig,
             );
-            return generator.injectClientScript(html);
+            return generator.injectDevelopmentClientScript(html);
         },
 
         async configResolved(resolvedConfig: ResolvedConfig) {

--- a/test/generator.test.ts
+++ b/test/generator.test.ts
@@ -132,5 +132,31 @@ describe('RedirectGenerator', () => {
             );
             expect(content).toContain('<link rel="canonical" href="/new">');
         });
+
+        it('should inject client script for immediate redirect when delay is 0', async () => {
+            const options: Required<RedirectOptions> = {
+                ...defaultOptions,
+                redirectDelay: 0,
+            };
+
+            const generator = new RedirectGenerator(
+                { '/instant': '/target' },
+                options,
+                mockVitePressConfig,
+            );
+
+            await generator.generateAllRedirectFiles('/test/dist');
+
+            const files = vol.toJSON();
+            const content = files['/test/dist/instant/index.html'] as string;
+
+            // Should have meta refresh AND client script for immediate redirect
+            expect(content).toContain(
+                '<meta http-equiv="refresh" content="0; url=/target">',
+            );
+            expect(content).toContain('function performRedirect()');
+            expect(content).toContain('location.replace');
+            expect(content).toContain('location.replace(destination)');
+        });
     });
 });

--- a/test/generator.test.ts
+++ b/test/generator.test.ts
@@ -45,7 +45,7 @@ describe('RedirectGenerator', () => {
 
             const html =
                 '<html><head><title>Test</title></head><body></body></html>';
-            const result = generator.injectClientScript(html);
+            const result = generator.injectDevelopmentClientScript(html);
 
             expect(result).toContain('<script>');
             expect(result).toContain('function performRedirect()');
@@ -62,7 +62,7 @@ describe('RedirectGenerator', () => {
             );
 
             const html = '<html><head></head><body></body></html>';
-            const result = generator.injectClientScript(html);
+            const result = generator.injectDevelopmentClientScript(html);
 
             expect(result).toContain('const redirects = {}');
         });
@@ -154,9 +154,11 @@ describe('RedirectGenerator', () => {
             expect(content).toContain(
                 '<meta http-equiv="refresh" content="0; url=/target">',
             );
-            expect(content).toContain('function performRedirect()');
-            expect(content).toContain('location.replace');
-            expect(content).toContain('location.replace(destination)');
+
+            // destination variable definition
+            expect(content).toContain(`var d=${JSON.stringify('/target')}`);
+            expect(content).toContain('location.replace(d)'); // try block
+            expect(content).toContain('location.href=d'); // catch block
         });
     });
 });


### PR DESCRIPTION
If `redirectDelay` is `0`, perform the redirect immediately using JavaScript, rather than waiting for the page to load and then relying on meta refresh as the primary method.